### PR TITLE
Check for user trying to replace content with the exact same content

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,4 +760,4 @@ EZ WildApricot Web Designer is supported on the latest versions of Chrome, Safar
 - added instructions on adding translated content gadgets
 - added "step through" debugging mechanism to process config and language files line by line with delay
 
-2.1.1 - fixed infinite loop bug that was encountered when the default text contained a substring or the an identical string in the replacement text
+2.1.1 - fixed infinite loop bug that was encountered when the default text contained a substring or the an identical string in the replacement text 07/06/2023

--- a/README.md
+++ b/README.md
@@ -759,3 +759,5 @@ EZ WildApricot Web Designer is supported on the latest versions of Chrome, Safar
 - third-party script files are now included, removing requirement for domain whitelisting
 - added instructions on adding translated content gadgets
 - added "step through" debugging mechanism to process config and language files line by line with delay
+
+2.1.1 - fixed infinite loop bug that was encountered when the default text contained a substring or the an identical string in the replacement text

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ short_delay = 1;
 **EXAMPLE:**
 
 ```text
+Default Text: Home
 Replacement Text: Coordonnées
 Function: shortdelay
 Query: #membersTable > thead > tr > th:nth-child(1)
@@ -390,6 +391,7 @@ long_delay = 3;
 **EXAMPLE:**
 
 ```text
+Default Text: Home
 Replacement Text: Coordonnées
 Function: longdelay
 Query: #membersTable > thead > tr > th:nth-child(1)
@@ -397,7 +399,7 @@ Query: #membersTable > thead > tr > th:nth-child(1)
 
 ## **button**
 
-> Changes the text on targeted button(s). The search is done without case sensitivity.
+> Changes the text on targeted button(s). Note that the Default Text is empty (and ignored if filled) when using the button function.
 
 **EXAMPLE:**
 
@@ -409,7 +411,7 @@ Query: .loginButton
 
 ## **delaybutton**
 
-> Changes the text on targeted button(s), after a 1 second delay, useful for widgets that have a JavaScript rendering delay
+> Changes the text on targeted button(s), after a 1 second delay, useful for widgets that have a JavaScript rendering delay. Note that the Default Text is empty (and ignored if filled) when using the delaybutton function.
 
 **EXAMPLE:**
 

--- a/WildApricotTextManager/scripts/functions.js
+++ b/WildApricotTextManager/scripts/functions.js
@@ -425,7 +425,8 @@ const replace_link_delay = (
     return;
   }
   if (
-    !replacementText.toLowerCase().includes(defaultText.toLowerCase()) &&
+    (!replacementText.toLowerCase().includes(defaultText.toLowerCase()) ||
+      !defaultText.toLowerCase() == replacementText.toLowerCase()) &&
     watmFunction === "replace"
   ) {
     document.querySelectorAll(watmQuery).forEach(function (el) {
@@ -435,7 +436,8 @@ const replace_link_delay = (
       });
     });
   } else if (
-    replacementText.toLowerCase().includes(defaultText.toLowerCase()) &&
+    (replacementText.toLowerCase().includes(defaultText.toLowerCase()) ||
+      defaultText.toLowerCase() == replacementText.toLowerCase()) &&
     watmFunction === "replace"
   ) {
     storeError(

--- a/WildApricotTextManager/scripts/functions.js
+++ b/WildApricotTextManager/scripts/functions.js
@@ -426,7 +426,7 @@ const replace_link_delay = (
   }
   if (
     (!replacementText.toLowerCase().includes(defaultText.toLowerCase()) ||
-      !defaultText.toLowerCase() == replacementText.toLowerCase()) &&
+      !defaultText.toLowerCase() === replacementText.toLowerCase()) &&
     watmFunction === "replace"
   ) {
     document.querySelectorAll(watmQuery).forEach(function (el) {

--- a/WildApricotTextManager/scripts/functions.js
+++ b/WildApricotTextManager/scripts/functions.js
@@ -437,7 +437,7 @@ const replace_link_delay = (
     });
   } else if (
     (replacementText.toLowerCase().includes(defaultText.toLowerCase()) ||
-      defaultText.toLowerCase() == replacementText.toLowerCase()) &&
+      defaultText.toLowerCase() === replacementText.toLowerCase()) &&
     watmFunction === "replace"
   ) {
     storeError(

--- a/WildApricotTextManager/scripts/functions.js
+++ b/WildApricotTextManager/scripts/functions.js
@@ -426,7 +426,7 @@ const replace_link_delay = (
   }
   if (
     (!replacementText.toLowerCase().includes(defaultText.toLowerCase()) ||
-      !defaultText.toLowerCase() === replacementText.toLowerCase()) &&
+      defaultText.toLowerCase() !== replacementText.toLowerCase()) &&
     watmFunction === "replace"
   ) {
     document.querySelectorAll(watmQuery).forEach(function (el) {

--- a/WildApricotTextManager/wildapricot-textmanager.js
+++ b/WildApricotTextManager/wildapricot-textmanager.js
@@ -11,7 +11,7 @@ const watm_location = document.currentScript.src.substring(
  * The version number of the WATM script.
  * @constant {string}
  */
-const watm_version = "2.1.0";
+const watm_version = "2.1.1";
 
 /**
  * The URL of the WATM information page.


### PR DESCRIPTION
Checking if the replacement text contains the default text has already been implemented: https://github.com/NewPath-Consulting/ez-wildapricot-webdesigner/blob/c5a75541dbd7c2a7c5d0f466100297baafe017fc/WildApricotTextManager/scripts/functions.js#L427-L430

This update now checks if the user is trying to replace content with itself, resulting in an indefinite loop: https://github.com/NewPath-Consulting/ez-wildapricot-webdesigner/blob/1b6642fdf3564b109c91fccc152fa3726ab6e5d1/WildApricotTextManager/scripts/functions.js#L427-L431